### PR TITLE
Write warm water target temperature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ km271.config
 km271.creator*
 km271.cxxflags
 km271.files
-km271.include
+km271.includes
+*~

--- a/README.md
+++ b/README.md
@@ -17,11 +17,26 @@ See https://esphome.io/components/external_components.html for information about
 
 To configure the component, see the included file buderus-km271.yaml.
 If you are not interested in some of the provided values, just remove the respective entry in the the section "sensor" or "binary_sensor", but leave the empty sections in place to avoid comiler errors with missing headers.
- 
+
+#### Writing Values and Changing Parameters 
+If you plan to change settings for your heater, see the included file buderus-km271-writable.yaml. This file also provides integration for changing values via home assistant.
+
+*CAUTION*: 
+Changing settings of your heater might lead to undesired results, e.g. increased fuel consumption, annoyed family members or even failure of your device.
+Please use caution when changing settings of your heater and verify that the results are as desired. Rule of thumb: If you don't feel comfortable changing the settings directly on the heater control unit,
+do dot do it via this software either.
+
+*MORE CAUTION*: 
+If you plan to change settings, please take care not to change settings too
+frequently. Devices such as these heaters typically use so called EEPROM chips to store settings. Such chips only support a certain number of write operations before breaking down.
+You should be safe for some years if you don't write more 20 values per day - but there is no guarantee. Maybe someone can dig out some documentation about this to make sure.
+
 ### Limitations
    * The software only provides a sub-set of the available data. Feel free to create a pull request to add data you want to see.
-   * Changing of values (e.g. target temperatures) is not yet supported. This is planned for a later version.
- 
+   * Changing of values is only supported for a few values
+   * Only one write request can be active at the same time
+   * Written values are not read back for verification.
+
 ### Notes by Jens
 I'm working on this project as a hobby. My work on this software is in no way associated with a company. If you like to use it, or improve on it, feel free.
 Use it at your own risk - it might work perfectly or it might not.

--- a/buderus-km271-writable.yaml
+++ b/buderus-km271-writable.yaml
@@ -1,0 +1,9 @@
+switch:
+  - platform: km271_wifi
+    warm_water_heating_auto_off:
+      name: "Warmwasserbereitung Auto/Nacht"
+
+number:
+  - platform: km271_wifi
+    warm_water_temperature:
+      name: "Warmwassersolltemperatur Tag"

--- a/buderus-km271.yaml
+++ b/buderus-km271.yaml
@@ -74,6 +74,8 @@ binary_sensor:
     boiler_actuation:
       name: "Brenneransteuerung"
 
+number:
+
 sensor:
   - platform: km271_wifi
     heating_circuit_1_flow_target_temperature:

--- a/components/km271_wifi/3964r.cpp
+++ b/components/km271_wifi/3964r.cpp
@@ -104,7 +104,7 @@ void Writer3964R::reset()
     retryCount = 0;
 }
 
-void Writer3964R::enqueueTelegram(uint8_t *data, uint16_t length)
+void Writer3964R::enqueueTelegram(const uint8_t *data, uint16_t length)
 {
     if(writerState != Idle) {
         ESP_LOGE(TAG, "Writer not idle");
@@ -114,6 +114,7 @@ void Writer3964R::enqueueTelegram(uint8_t *data, uint16_t length)
         ESP_LOGE(TAG, "Telegram too long %d", length);
         return;
     }
+    ESP_LOGD(TAG, "Enqueuing telegram of length %d", length);
 
     hasUnhandledDLE = false;
     bytesSent = 0;

--- a/components/km271_wifi/3964r.h
+++ b/components/km271_wifi/3964r.h
@@ -65,7 +65,7 @@ class Writer3964R
 public:
     Writer3964R();
     void reset();
-    void enqueueTelegram(uint8_t *data, uint16_t length);
+    void enqueueTelegram(const uint8_t *data, uint16_t length);
     void setSTXSent();
     uint8_t popNextByte();
     bool hasByteToSend();

--- a/components/km271_wifi/README.md
+++ b/components/km271_wifi/README.md
@@ -82,3 +82,7 @@ An example yaml could be also found in this GIT repo.
           name: "Außentemperatur"
         attenuated_outdoor_temperature:
           name: "Gedaempfte Aussentemperatur"
+
+    switch:
+
+    number:

--- a/components/km271_wifi/km271.h
+++ b/components/km271_wifi/km271.h
@@ -15,6 +15,8 @@
 
 #define GENERATE_SENSOR_SETTER(key, parameterId) void set_##key##_sensor(esphome::sensor::Sensor *sensor) { set_sensor(parameterId, sensor); }
 #define GENERATE_BINARY_SENSOR_SETTER(key, parameterId) void set_##key##_binary_sensor(esphome::binary_sensor::BinarySensor *sensor) { set_binary_sensor(parameterId, sensor); }
+#define GENERATE_SWITCH_SETTER(key, parameterId) void set_##key##_switch(BuderusParamSwitch *switch_) { set_switch(parameterId, switch_); }
+#define GENERATE_NUMBER_SETTER(key, parameterId) void set_##key##_number(BuderusParamNumber *number) { set_number(parameterId, number); }
 
 
 namespace esphome {
@@ -60,6 +62,9 @@ class KM271Component : public Component, public uart::UARTDevice {
   GENERATE_BINARY_SENSOR_SETTER(boiler_running, KBETR);
   GENERATE_BINARY_SENSOR_SETTER(boiler_actuation, BANST);
 
+  GENERATE_SWITCH_SETTER(warm_water_heating_auto_off, CFG_WW_Aufbereitung);
+  GENERATE_NUMBER_SETTER(warm_water_temperature, CFG_WW_Temperatur);
+
   void setup();
   float get_setup_priority() const override;
   void update();
@@ -67,8 +72,12 @@ class KM271Component : public Component, public uart::UARTDevice {
 
 
  protected:
+  t_Buderus_R2017_ParamDesc * findParameterForNewSensor(Buderus_R2017_ParameterId parameterId, bool writableRequired);
   void set_sensor(Buderus_R2017_ParameterId parameterId, esphome::sensor::Sensor *sensor);
   void set_binary_sensor(Buderus_R2017_ParameterId parameterId, esphome::binary_sensor::BinarySensor *sensor);
+  void set_switch(Buderus_R2017_ParameterId parameterId, BuderusParamSwitch *switch_);
+  void set_number(Buderus_R2017_ParameterId parameterId, BuderusParamNumber *number);
+
 
 
   void process_incoming_byte(uint8_t c);

--- a/components/km271_wifi/km271.h
+++ b/components/km271_wifi/km271.h
@@ -73,12 +73,11 @@ class KM271Component : public Component, public uart::UARTDevice {
 
  protected:
   t_Buderus_R2017_ParamDesc * findParameterForNewSensor(Buderus_R2017_ParameterId parameterId, bool writableRequired);
+
   void set_sensor(Buderus_R2017_ParameterId parameterId, esphome::sensor::Sensor *sensor);
   void set_binary_sensor(Buderus_R2017_ParameterId parameterId, esphome::binary_sensor::BinarySensor *sensor);
   void set_switch(Buderus_R2017_ParameterId parameterId, BuderusParamSwitch *switch_);
   void set_number(Buderus_R2017_ParameterId parameterId, BuderusParamNumber *number);
-
-
 
   void process_incoming_byte(uint8_t c);
   void parse_buderus(uint8_t * buf, size_t len);
@@ -91,12 +90,11 @@ class KM271Component : public Component, public uart::UARTDevice {
   size_t genDataString(char* outbuf, uint8_t* inbuf, size_t len);
   void print_hex_buffer(uint8_t* buf, size_t len);
 
-
   uint32_t last_received_byte_time;
-
-
   Parser3964R parser;
   Writer3964R writer;
+  /** used to call the loop function of the sensors every x calls to the loop function of the component */
+  uint8_t sensorLoopCounter;
 };
 
 } // namespace KM271

--- a/components/km271_wifi/km271_params.cpp
+++ b/components/km271_wifi/km271_params.cpp
@@ -127,7 +127,6 @@ void BuderusParamSensor::loop()
 BuderusParamSwitch::BuderusParamSwitch():
     writer(nullptr)
 {
-
 }
 
 void BuderusParamSwitch::setupWriting(Writer3964R *writer, Buderus_R2017_ParameterId parameterId, SensorType sensorType)
@@ -135,7 +134,6 @@ void BuderusParamSwitch::setupWriting(Writer3964R *writer, Buderus_R2017_Paramet
     this->writer = writer;
     this->parameterId = parameterId;
     this->sensorType = sensorType;
-
 }
 
 void BuderusParamSwitch::write_state(bool state)
@@ -157,15 +155,12 @@ void BuderusParamSwitch::write_state(bool state)
     } else {
         ESP_LOGE(TAG, "No write configuration for parameter %d found", parameterId);
     }
-
-
 }
 
 BuderusParamNumber::BuderusParamNumber():
     writer(nullptr),
     hasPendingWriteRequest(false)
 {
-
 }
 
 void BuderusParamNumber::setupWriting(Writer3964R *writer, Buderus_R2017_ParameterId parameterId, SensorType sensorType)

--- a/components/km271_wifi/km271_params.cpp
+++ b/components/km271_wifi/km271_params.cpp
@@ -1,26 +1,66 @@
 #include "km271_params.h"
 #include "esphome/core/log.h"
 #include "esphome/core/util.h"
+#include "esphome/core/hal.h"
 #include <stdint.h>
+#include "3964r.h"
 
 namespace esphome {
 namespace KM271 {
 
 static const char *const TAG = "BPARM";
 
-BuderusParamSensor::BuderusParamSensor(esphome::sensor::Sensor *sensor,  SensorType sensorType):
+BuderusParamSensor::BuderusParamSensor(esphome::sensor::Sensor *sensor,  SensorType sensorType, uint8_t sensorTypeParam):
     sensor(sensor),
     binarySensor(nullptr),
-    sensorType(sensorType)
+    switch_(nullptr),
+    number(nullptr),
+    sensorType(sensorType),
+    sensorTypeParam(sensorTypeParam)
 {
 
 }
 
-BuderusParamSensor::BuderusParamSensor(esphome::binary_sensor::BinarySensor *sensor):
+BuderusParamSensor::BuderusParamSensor(esphome::binary_sensor::BinarySensor *sensor, SensorType sensorType, uint8_t sensorTypeParam):
     sensor(nullptr),
-    binarySensor(sensor)
+    binarySensor(sensor),
+    switch_(nullptr),
+    number(nullptr),
+    sensorType(sensorType),
+    sensorTypeParam(sensorTypeParam)
 {
 
+}
+
+BuderusParamSensor::BuderusParamSensor(BuderusParamSwitch *switch_, SensorType sensorType, uint8_t sensorTypeParam):
+    sensor(nullptr),
+    binarySensor(nullptr),
+    switch_(switch_),
+    number(nullptr),
+    sensorType(sensorType),
+    sensorTypeParam(sensorTypeParam)
+{
+
+}
+
+BuderusParamSensor::BuderusParamSensor(BuderusParamNumber *paramNumber, SensorType sensorType, uint8_t sensorTypeParam):
+    sensor(nullptr),
+    binarySensor(nullptr),
+    switch_(nullptr),
+    number(paramNumber),
+    sensorType(sensorType),
+    sensorTypeParam(sensorTypeParam)
+{
+
+}
+
+uint32_t parseInt(uint8_t *data, size_t len)
+{
+    uint32_t value = 0;
+    for (int i=0; i<len; i++) {
+        value = (value << 8) + data[i];
+    }
+    return value;
 }
 
 void BuderusParamSensor::parseAndTransmit(uint8_t *data, size_t len)
@@ -28,10 +68,7 @@ void BuderusParamSensor::parseAndTransmit(uint8_t *data, size_t len)
     if (sensor) {
         if (sensorType == INT) {
             ESP_LOGD(TAG, "Found int with length %d", len);
-            uint32_t value = 0;
-            for (int i=0; i<len; i++) {
-                value = (value << 8) + data[i];
-            }
+            uint32_t value = parseInt(data, len);
             sensor->publish_state(value);
         } 
         else if (sensorType == INTDIVIDEDBY2) {
@@ -43,12 +80,139 @@ void BuderusParamSensor::parseAndTransmit(uint8_t *data, size_t len)
             sensor->publish_state(((float)value) / 2.0f);
         }
         else {
-          ESP_LOGD(TAG, "Sensor type %d NYI", sensorType);
+            ESP_LOGW(TAG, "Sensor type %d NYI", sensorType);
         }
     } else if(binarySensor) {
         binarySensor->publish_state(data[len-1] > 0);
+    } else if(switch_) {
+        if (sensorType == TAG_NACHT_AUTO_SELECT) {
+            ESP_LOGD(TAG, "Found tag/nacht/auto select length %d: %s", len, (char *)data);
+            if(data[0] == 0) { // nacht
+                switch_->publish_state(false);
+            } else if(data[0] == 1 || data[0] == 2) { // tag, auto
+                switch_->publish_state(true);
+            } else {
+                ESP_LOGW(TAG, "Invalid value for tag/nacht/auto select: %d %c %c ...", len, data[0], data[1]);
+            }
+        } else {
+            ESP_LOGW(TAG, "Sensor type %d NYI for switch", sensorType);
+        }
+    } else if(number) {
+        if (sensorType == INT) {
+            uint32_t value = parseInt(data, len);
+            number->publish_state(value);
+        } else if(sensorType == BYTE_AT_OFFSET) {
+            if (sensorTypeParam < len) {
+                uint8_t value = data[sensorTypeParam];
+                number->publish_state(value);
+            } else {
+                ESP_LOGE(TAG, "Offset for sensor type BYTE_AT_OFFSET %d > data len %d", sensorTypeParam, len);
+            }
+        } else {
+            ESP_LOGE(TAG, "Sensor type %d NYI for number", sensorType);
+        }
+
     } else {
-        ESP_LOGE(TAG, "No sensor or binary sensor defined");
+        ESP_LOGE(TAG, "No sensor, binary sensor or switch defined");
+    }
+}
+
+void BuderusParamSensor::loop()
+{
+  if(number) {
+      number->loop();
+  }
+}
+
+BuderusParamSwitch::BuderusParamSwitch():
+    writer(nullptr)
+{
+
+}
+
+void BuderusParamSwitch::setupWriting(Writer3964R *writer, Buderus_R2017_ParameterId parameterId, SensorType sensorType)
+{
+    this->writer = writer;
+    this->parameterId = parameterId;
+    this->sensorType = sensorType;
+
+}
+
+void BuderusParamSwitch::write_state(bool state)
+{
+    const uint8_t keep = 0x65;
+    const uint8_t data_type_warm_water = 0x0c;
+
+    if (parameterId == CFG_WW_Aufbereitung) {
+        const uint8_t automatic = 2;
+        const uint8_t day = 1;
+        const uint8_t night = 0;
+
+        const uint8_t value = state ? automatic : night;
+
+        const uint8_t message[] = { data_type_warm_water, 0x0E, value, keep, keep, keep, keep, keep};
+        writer->enqueueTelegram(message, 8);
+        publish_state(state); // confirm for now without waiting for an ack from the heater
+
+    } else {
+        ESP_LOGE(TAG, "No write configuration for parameter %d found", parameterId);
+    }
+
+
+}
+
+BuderusParamNumber::BuderusParamNumber():
+    writer(nullptr),
+    hasPendingWriteRequest(false)
+{
+
+}
+
+void BuderusParamNumber::setupWriting(Writer3964R *writer, Buderus_R2017_ParameterId parameterId, SensorType sensorType)
+{
+    this->writer = writer;
+    this->parameterId = parameterId;
+    this->sensorType = sensorType;
+}
+
+void BuderusParamNumber::control(float value)
+{
+    const uint8_t keep = 0x65;
+    const uint8_t data_type_warm_water = 0x0c;
+
+    if(parameterId == CFG_WW_Temperatur) {
+        float target_temperature = value;
+        if (target_temperature < 30) {
+            target_temperature = 30;
+        } else if (target_temperature > 60) {
+            target_temperature = 60;
+        }
+
+        // do not write directly, but instead wait until the value does not change for some time and write then
+        // this is to avoid writing to the heater each time the user clicks on the up arrow
+        this->hasPendingWriteRequest = true;
+        this->pendingWriteValue = target_temperature;
+        this->lastWriteRequest = millis();
+
+    } else {
+        ESP_LOGE(TAG, "No write configuration for number parameter %d found", parameterId);
+    }
+}
+
+void BuderusParamNumber::loop()
+{
+    uint32_t writeConsolidationPeriod = 1000;
+    const uint8_t keep = 0x65;
+    const uint8_t data_type_warm_water = 0x0c;
+
+    if (this->hasPendingWriteRequest) {
+        uint32_t now = millis();
+        if (now - lastWriteRequest > writeConsolidationPeriod) {
+            this->hasPendingWriteRequest = false;
+            const uint8_t message[] = { data_type_warm_water, 0x07, keep, keep, keep, (uint8_t)this->pendingWriteValue, keep, keep};
+            writer->enqueueTelegram(message, 8);
+            publish_state(this->pendingWriteValue);
+        }
     }
 }
 

--- a/components/km271_wifi/number.py
+++ b/components/km271_wifi/number.py
@@ -1,0 +1,49 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import number
+from esphome.const import (
+    CONF_ID,
+    CONF_MIN_VALUE,
+    CONF_MAX_VALUE
+)
+
+from . import (
+    CONF_KM271_ID,
+    KM271
+)
+
+CODEOWNERS = ["@jensgraef"]
+
+TYPES = [
+    "warm_water_temperature"
+]
+
+km271_ns = cg.esphome_ns.namespace("KM271")
+
+BuderusParamNumber = km271_ns.class_("BuderusParamNumber", number.Number, cg.Component)
+
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(CONF_KM271_ID): cv.use_id(KM271),
+            cv.Optional("warm_water_temperature"): number.NUMBER_SCHEMA.extend({
+                cv.GenerateID(): cv.declare_id(BuderusParamNumber),
+            })
+        }
+    )
+)
+
+
+async def setup_conf(config, key, hub):
+    if key in config:
+        conf = config[key]
+
+        sens = await number.new_number(conf, min_value=30, max_value=60)
+        cg.add(getattr(hub, f"set_{key}_number")(sens))
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_KM271_ID])
+    for key in TYPES:
+        await setup_conf(config, key, hub)

--- a/components/km271_wifi/switch.py
+++ b/components/km271_wifi/switch.py
@@ -1,0 +1,45 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import switch
+from esphome.const import (
+    CONF_ID
+)
+
+from . import (
+    CONF_KM271_ID,
+    KM271
+)
+
+CODEOWNERS = ["@the78mole", "@jensgraef"]
+
+TYPES = [
+    "warm_water_heating_auto_off"
+]
+
+km271_ns = cg.esphome_ns.namespace("KM271")
+
+BuderusParamSwitch = km271_ns.class_("BuderusParamSwitch", switch.Switch, cg.Component)
+
+
+CONFIG_SCHEMA = (
+    cv.Schema(
+        {
+            cv.GenerateID(CONF_KM271_ID): cv.use_id(KM271),
+            cv.Optional("warm_water_heating_auto_off"): switch.switch_schema(BuderusParamSwitch),
+        }
+    )
+)
+
+
+async def setup_conf(config, key, hub):
+    if key in config:
+        conf = config[key]
+
+        sens = await switch.new_switch(conf)
+        cg.add(getattr(hub, f"set_{key}_switch")(sens))
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_KM271_ID])
+    for key in TYPES:
+        await setup_conf(config, key, hub)


### PR DESCRIPTION
This merge requests adds a switch to toggle warm water heating between the modes auto and night. This allows to turn of warm water heating remotely e.g. when nobody is at home.

Futhermore this merge request adds a number control for the warm water target temperature.

See Readme for some words of caution about changing device parameters.