### PR TITLE
fix startup error on home assistant if warm water number field is used

### DIFF
--- a/components/km271_wifi/number.py
+++ b/components/km271_wifi/number.py
@@ -39,7 +39,7 @@ async def setup_conf(config, key, hub):
     if key in config:
         conf = config[key]
 
-        sens = await number.new_number(conf, min_value=30, max_value=60)
+        sens = await number.new_number(conf, min_value=30, max_value=60, step=1)
         cg.add(getattr(hub, f"set_{key}_number")(sens))
 
 


### PR DESCRIPTION
add step parameter to number. if it is missing the esp home integration will raise an exception on startup.

This fixes #18 