### PR TITLE
Support single bit sensors

### DIFF
--- a/buderus-km271.yaml
+++ b/buderus-km271.yaml
@@ -67,6 +67,8 @@ binary_sensor:
   - platform: km271_wifi
     load_pump_running:
       name: "Ladepumpenbetrieb"
+    circulation_pump_running:
+      name: "Zirkulationspumpenbetrieb"
     boiler_error:
       name: "Kesselfehler"
     boiler_running:

--- a/components/km271_wifi/binary_sensor.py
+++ b/components/km271_wifi/binary_sensor.py
@@ -21,6 +21,7 @@ CODEOWNERS = ["@the78mole", "@jensgraef"]
 
 TYPES = [
     "load_pump_running",
+    "circulation_pump_running",
     "boiler_error",
     "boiler_running",
     "boiler_actuation"
@@ -33,19 +34,23 @@ CONFIG_SCHEMA = (
             cv.GenerateID(CONF_KM271_ID): cv.use_id(KM271),
             cv.Optional("load_pump_running"): binary_sensor.binary_sensor_schema(
                 device_class=DEVICE_CLASS_RUNNING,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,	
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional("circulation_pump_running"): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_RUNNING,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional("boiler_error"): binary_sensor.binary_sensor_schema(
                 device_class=DEVICE_CLASS_PROBLEM,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC, 	
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional("boiler_running"): binary_sensor.binary_sensor_schema(
                 device_class=DEVICE_CLASS_RUNNING,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC, 	
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional("boiler_actuation"): binary_sensor.binary_sensor_schema(
                 device_class=DEVICE_CLASS_POWER,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC, 
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
         }
     )

--- a/components/km271_wifi/km271.cpp
+++ b/components/km271_wifi/km271.cpp
@@ -186,11 +186,11 @@ void KM271Component::on_shutdown() {
     ESP_LOGI(TAG, "Shutdown was called");
 }
 
-const t_Buderus_R2017_ParamDesc * KM271Component::findParameterForNewSensor(Buderus_R2017_ParameterId parameterId, bool writableRequired)
+const t_Buderus_R2017_ParamDesc * KM271Component::findParameterForNewSensor(Buderus_R2017_ParameterId parameterId, uint16_t sensorTypeParam, bool writableRequired)
 {
     for(int i = 0; i < lenof(buderusParamDesc); i++) {
         const t_Buderus_R2017_ParamDesc * pDesc = &buderusParamDesc[i];
-        if(pDesc->parameterId == parameterId) {
+        if(pDesc->parameterId == parameterId && pDesc->sensorTypeParam == sensorTypeParam) {
             if (writableRequired && !pDesc->writable) {
                 ESP_LOGE(TAG, "Parameter %d is not writable", parameterId);
                 return nullptr;
@@ -201,9 +201,9 @@ const t_Buderus_R2017_ParamDesc * KM271Component::findParameterForNewSensor(Bude
     return nullptr;
 }
 
-void KM271Component::set_sensor(Buderus_R2017_ParameterId parameterId, esphome::sensor::Sensor *sensor)
+void KM271Component::set_sensor(Buderus_R2017_ParameterId parameterId, uint16_t sensorTypeParam, esphome::sensor::Sensor *sensor)
 {
-    const t_Buderus_R2017_ParamDesc* pDesc = findParameterForNewSensor(parameterId, false);
+    const t_Buderus_R2017_ParamDesc* pDesc = findParameterForNewSensor(parameterId, sensorTypeParam, false);
     if (!pDesc) {
         ESP_LOGE(TAG, "set_sensor: No available slot for parameter ID %d found", parameterId);
         return;
@@ -211,9 +211,9 @@ void KM271Component::set_sensor(Buderus_R2017_ParameterId parameterId, esphome::
     valueHandlerMap.insert(std::pair<Buderus_R2017_ParameterId, BuderusValueHandler *>(parameterId, new BuderusValueHandler(pDesc, sensor)));
 }
 
-void KM271Component::set_binary_sensor(Buderus_R2017_ParameterId parameterId, esphome::binary_sensor::BinarySensor *sensor)
+void KM271Component::set_binary_sensor(Buderus_R2017_ParameterId parameterId, uint16_t sensorTypeParam, esphome::binary_sensor::BinarySensor *sensor)
 {
-    const t_Buderus_R2017_ParamDesc* pDesc = findParameterForNewSensor(parameterId, false);
+    const t_Buderus_R2017_ParamDesc* pDesc = findParameterForNewSensor(parameterId, sensorTypeParam, false);
     if (!pDesc) {
         ESP_LOGE(TAG, "set_binary_sensor: No available slot for parameter ID %d found", parameterId);
         return;
@@ -222,9 +222,9 @@ void KM271Component::set_binary_sensor(Buderus_R2017_ParameterId parameterId, es
     valueHandlerMap.insert(std::pair<Buderus_R2017_ParameterId, BuderusValueHandler *>(parameterId, new BuderusValueHandler(pDesc, sensor)));
 }
 
-void KM271Component::set_switch(Buderus_R2017_ParameterId parameterId, BuderusParamSwitch *switch_)
+void KM271Component::set_switch(Buderus_R2017_ParameterId parameterId, uint16_t sensorTypeParam, BuderusParamSwitch *switch_)
 {
-    const t_Buderus_R2017_ParamDesc* pDesc = findParameterForNewSensor(parameterId, true);
+    const t_Buderus_R2017_ParamDesc* pDesc = findParameterForNewSensor(parameterId, sensorTypeParam, true);
     if (!pDesc) {
         ESP_LOGE(TAG, "set_switch: No available slot for parameter ID %d found", parameterId);
         return;
@@ -235,9 +235,9 @@ void KM271Component::set_switch(Buderus_R2017_ParameterId parameterId, BuderusPa
     valueHandlerMap.insert(std::pair<Buderus_R2017_ParameterId, BuderusValueHandler *>(parameterId, new BuderusValueHandler(pDesc, switch_)));
 }
 
-void KM271Component::set_number(Buderus_R2017_ParameterId parameterId, BuderusParamNumber *number)
+void KM271Component::set_number(Buderus_R2017_ParameterId parameterId, uint16_t sensorTypeParam,BuderusParamNumber *number)
 {
-    const t_Buderus_R2017_ParamDesc* pDesc = findParameterForNewSensor(parameterId, true);
+    const t_Buderus_R2017_ParamDesc* pDesc = findParameterForNewSensor(parameterId, sensorTypeParam, true);
     if (!pDesc) {
         ESP_LOGE(TAG, "set_number: No available slot for parameter ID %d found", parameterId);
         return;

--- a/components/km271_wifi/km271.h
+++ b/components/km271_wifi/km271.h
@@ -13,10 +13,14 @@
 #include "km271_params.h"
 
 
-#define GENERATE_SENSOR_SETTER(key, parameterId) void set_##key##_sensor(esphome::sensor::Sensor *sensor) { set_sensor(parameterId, sensor); }
-#define GENERATE_BINARY_SENSOR_SETTER(key, parameterId) void set_##key##_binary_sensor(esphome::binary_sensor::BinarySensor *sensor) { set_binary_sensor(parameterId, sensor); }
-#define GENERATE_SWITCH_SETTER(key, parameterId) void set_##key##_switch(BuderusParamSwitch *switch_) { set_switch(parameterId, switch_); }
-#define GENERATE_NUMBER_SETTER(key, parameterId) void set_##key##_number(BuderusParamNumber *number) { set_number(parameterId, number); }
+#define GENERATE_SENSOR_SETTER(key, parameterId, sensorTypeParam) void set_##key##_sensor(esphome::sensor::Sensor *sensor) \
+  { set_sensor(parameterId, sensorTypeParam, sensor); }
+#define GENERATE_BINARY_SENSOR_SETTER(key, parameterId, sensorTypeParam) void set_##key##_binary_sensor(esphome::binary_sensor::BinarySensor *sensor) \
+  { set_binary_sensor(parameterId, sensorTypeParam, sensor); }
+#define GENERATE_SWITCH_SETTER(key, parameterId, sensorTypeParam) void set_##key##_switch(BuderusParamSwitch *switch_) \
+  { set_switch(parameterId, sensorTypeParam, switch_); }
+#define GENERATE_NUMBER_SETTER(key, parameterId, sensorTypeParam) void set_##key##_number(BuderusParamNumber *number) \
+  { set_number(parameterId, sensorTypeParam, number); }
 
 
 namespace esphome {
@@ -29,41 +33,42 @@ class KM271Component : public Component, public uart::UARTDevice {
   void loop() override;
   void dump_config() override;
 
-  GENERATE_SENSOR_SETTER(heating_circuit_1_flow_target_temperature, VSTHK1);
-  GENERATE_SENSOR_SETTER(heating_circuit_1_flow_temperature, VITHK1);
-  GENERATE_SENSOR_SETTER(heating_circuit_1_room_target_temperature, RSTHK1);
-  GENERATE_SENSOR_SETTER(heating_circuit_1_room_temperature, RITHK1);
-  GENERATE_SENSOR_SETTER(heating_circuit_1_pump_power, PLHK1);
-  GENERATE_SENSOR_SETTER(heating_circuit_1_mixer_position, MSHK1);
-  GENERATE_SENSOR_SETTER(heating_circuit_1_curve_p10, KLHK1_P10);
-  GENERATE_SENSOR_SETTER(heating_circuit_1_curve_0, KLHK1_P00);
-  GENERATE_SENSOR_SETTER(heating_circuit_1_curve_n10, KLHK1_N10);
-  GENERATE_SENSOR_SETTER(heating_circuit_2_flow_target_temperature, VSTHK2);
-  GENERATE_SENSOR_SETTER(heating_circuit_2_flow_temperature, VITHK2);
-  GENERATE_SENSOR_SETTER(heating_circuit_2_room_target_temperature, RSTHK2);
-  GENERATE_SENSOR_SETTER(heating_circuit_2_room_temperature, RITHK2);
-  GENERATE_SENSOR_SETTER(heating_circuit_2_pump_power, PLHK2);
-  GENERATE_SENSOR_SETTER(heating_circuit_2_mixer_position, MSHK2);
-  GENERATE_SENSOR_SETTER(heating_circuit_2_curve_p10, KLHK2_P10);
-  GENERATE_SENSOR_SETTER(heating_circuit_2_curve_0, KLHK2_P00);
-  GENERATE_SENSOR_SETTER(heating_circuit_2_curve_n10, KLHK2_N10);
-  GENERATE_SENSOR_SETTER(hot_water_target_temperature, WWST);
-  GENERATE_SENSOR_SETTER(hot_water_temperature, WWIT);
-  GENERATE_SENSOR_SETTER(boiler_target_temperature, KVST);
-  GENERATE_SENSOR_SETTER(boiler_temperature, KVIT);
-  GENERATE_SENSOR_SETTER(boiler_turn_on_temperature, BET);
-  GENERATE_SENSOR_SETTER(boiler_turn_off_temperature, BAT);
-  GENERATE_SENSOR_SETTER(exhaust_gas_temperature, ABTMP);
-  GENERATE_SENSOR_SETTER(outdoor_temperature, AT);
-  GENERATE_SENSOR_SETTER(attenuated_outdoor_temperature, ATD);
+  GENERATE_SENSOR_SETTER(heating_circuit_1_flow_target_temperature, VSTHK1, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_1_flow_temperature, VITHK1, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_1_room_target_temperature, RSTHK1, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_1_room_temperature, RITHK1, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_1_pump_power, PLHK1, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_1_mixer_position, MSHK1, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_1_curve_p10, KLHK1_P10, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_1_curve_0, KLHK1_P00, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_1_curve_n10, KLHK1_N10, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_2_flow_target_temperature, VSTHK2, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_2_flow_temperature, VITHK2, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_2_room_target_temperature, RSTHK2, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_2_room_temperature, RITHK2, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_2_pump_power, PLHK2, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_2_mixer_position, MSHK2, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_2_curve_p10, KLHK2_P10, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_2_curve_0, KLHK2_P00, 0);
+  GENERATE_SENSOR_SETTER(heating_circuit_2_curve_n10, KLHK2_N10, 0);
+  GENERATE_SENSOR_SETTER(hot_water_target_temperature, WWST, 0);
+  GENERATE_SENSOR_SETTER(hot_water_temperature, WWIT, 0);
+  GENERATE_SENSOR_SETTER(boiler_target_temperature, KVST, 0);
+  GENERATE_SENSOR_SETTER(boiler_temperature, KVIT, 0);
+  GENERATE_SENSOR_SETTER(boiler_turn_on_temperature, BET, 0);
+  GENERATE_SENSOR_SETTER(boiler_turn_off_temperature, BAT, 0);
+  GENERATE_SENSOR_SETTER(exhaust_gas_temperature, ABTMP, 0);
+  GENERATE_SENSOR_SETTER(outdoor_temperature, AT, 0);
+  GENERATE_SENSOR_SETTER(attenuated_outdoor_temperature, ATD, 0);
 
-  GENERATE_BINARY_SENSOR_SETTER(load_pump_running, LPWW);
-  GENERATE_BINARY_SENSOR_SETTER(boiler_error, KFEHL);
-  GENERATE_BINARY_SENSOR_SETTER(boiler_running, KBETR);
-  GENERATE_BINARY_SENSOR_SETTER(boiler_actuation, BANST);
+  GENERATE_BINARY_SENSOR_SETTER(load_pump_running, LPWW, 0);
+  GENERATE_BINARY_SENSOR_SETTER(circulation_pump_running, LPWW, 1);
+  GENERATE_BINARY_SENSOR_SETTER(boiler_error, KFEHL, 0);
+  GENERATE_BINARY_SENSOR_SETTER(boiler_running, KBETR, 0);
+  GENERATE_BINARY_SENSOR_SETTER(boiler_actuation, BANST, 0);
 
-  GENERATE_SWITCH_SETTER(warm_water_heating_auto_off, CFG_WW_Aufbereitung);
-  GENERATE_NUMBER_SETTER(warm_water_temperature, CFG_WW_Temperatur);
+  GENERATE_SWITCH_SETTER(warm_water_heating_auto_off, CFG_WW_Aufbereitung, 0);
+  GENERATE_NUMBER_SETTER(warm_water_temperature, CFG_WW_Temperatur, 3);
 
   void setup();
   float get_setup_priority() const override;
@@ -72,12 +77,12 @@ class KM271Component : public Component, public uart::UARTDevice {
   Writer3964R writer;
 
  protected:
-  const t_Buderus_R2017_ParamDesc *findParameterForNewSensor(Buderus_R2017_ParameterId parameterId, bool writableRequired);
+  const t_Buderus_R2017_ParamDesc *findParameterForNewSensor(Buderus_R2017_ParameterId parameterId, uint16_t sensorTypeParam, bool writableRequired);
 
-  void set_sensor(Buderus_R2017_ParameterId parameterId, esphome::sensor::Sensor *sensor);
-  void set_binary_sensor(Buderus_R2017_ParameterId parameterId, esphome::binary_sensor::BinarySensor *sensor);
-  void set_switch(Buderus_R2017_ParameterId parameterId, BuderusParamSwitch *switch_);
-  void set_number(Buderus_R2017_ParameterId parameterId, BuderusParamNumber *number);
+  void set_sensor(Buderus_R2017_ParameterId parameterId, uint16_t sensorTypeParam, esphome::sensor::Sensor *sensor);
+  void set_binary_sensor(Buderus_R2017_ParameterId parameterId, uint16_t sensorTypeParam, esphome::binary_sensor::BinarySensor *sensor);
+  void set_switch(Buderus_R2017_ParameterId parameterId, uint16_t sensorTypeParam, BuderusParamSwitch *switch_);
+  void set_number(Buderus_R2017_ParameterId parameterId, uint16_t sensorTypeParam, BuderusParamNumber *number);
 
   void process_incoming_byte(uint8_t c);
   void parse_buderus(uint8_t * buf, size_t len);

--- a/components/km271_wifi/km271_params.h
+++ b/components/km271_wifi/km271_params.h
@@ -110,7 +110,8 @@ enum SensorType {
     SIGNED_INT,
     UNSIGNED_INT_DIVIDED_BY_2,
     STRING,
-    BYTE_AT_OFFSET, // a single byte, with ofset in byte specified in sensor param
+    BYTE_AT_OFFSET, // a single byte, with offset in bytes specified in sensor param
+    BIT_AT_OFFSET, // a single bit, with offset in bits specified in sensor param
     TAG_NACHT_AUTO_SELECT, //   [ 0 => "Nacht", 1=> "Tag", 2=> "Automatik" ],
 };
 
@@ -234,8 +235,8 @@ static const t_Buderus_R2017_ParamDesc buderusParamDesc[] = {
         { WWST      , false, SensorType::UNSIGNED_INT, 0, "Warmwassersolltemperatur", "°C"},         // (Grad)
         { WWIT      , false, SensorType::UNSIGNED_INT, 0, "Warmwasseristtemperatur", "°C"},          // (Grad)
         { OZWW      , false, SensorType::UNSIGNED_INT, 0, "Warmwasseroptimierungszeit", ""},
-        { LPWW      , false, SensorType::UNSIGNED_INT, 0, "Ladepumpe", ""},                          // ["aus", "Ladepumpe", "Warmwasserpumpe", "beide"]
-
+        { LPWW      , false, SensorType::BIT_AT_OFFSET, 0, "Ladepumpe", "" },
+        { LPWW      , false, SensorType::BIT_AT_OFFSET, 1, "Zirkulationspumpe", "" },
         { KVST      , false, SensorType::UNSIGNED_INT, 0, "Kesselvorlaufsolltemperatur", "°C"},      // (Grad)
         { KVIT      , false, SensorType::UNSIGNED_INT, 0, "Kesselvorlaufisttemperatur", "°C"},       // (Grad)
         { BET       , false, SensorType::UNSIGNED_INT, 0, "Brennereinschalttemperatur", "°C"},       // (Grad)


### PR DESCRIPTION
This code adds support for parsing a single bit from a telegram into a binary sensor as discussed in #9 
It also adds the binary sensor "circulation pump active" with could previously not be discerned from "loading pump active".

Other bit sensors are yet to be added.
This pull request is based on #24.