### PR TITLE
Migrate to esphome 2025.2 and newer

### DIFF
--- a/buderus-km271.yaml
+++ b/buderus-km271.yaml
@@ -1,6 +1,7 @@
 esphome:
   name: buderus-km271
-  platform: ESP32
+
+esp32:
   board: esp32dev
 
 # Enable logging
@@ -10,6 +11,7 @@ logger:
 api:
 
 ota:
+  platform: esphome
   password: "put-your-ota-passphrase-here"  # Should be auto generated, when device is first created
 
 wifi:

--- a/components/km271_wifi/number.py
+++ b/components/km271_wifi/number.py
@@ -54,107 +54,107 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(CONF_KM271_ID): cv.use_id(KM271),
-            cv.Optional(CONF_FROSTT_SWITCH): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_FROSTT_SWITCH): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=10): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=-20): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.positive_float,
             }),
 
-            cv.Optional(CONF_HC1_ROOMT_TARGET_NIGHT): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_HC1_ROOMT_TARGET_NIGHT): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=30): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=10): cv.float_,
                 cv.Optional(CONF_STEP, default=0.5): cv.positive_float,
             }),
-            cv.Optional(CONF_HC1_ROOMT_TARGET_DAY): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_HC1_ROOMT_TARGET_DAY): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=30): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=10): cv.float_,
                 cv.Optional(CONF_STEP, default=0.5): cv.positive_float,
             }),
-            cv.Optional(CONF_HC1_HOLIDAYT): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_HC1_HOLIDAYT): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=30): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=10): cv.float_,
                 cv.Optional(CONF_STEP, default=0.5): cv.positive_float,
             }),
-            cv.Optional(CONF_HC1_FT_MAX): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_HC1_FT_MAX): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=90): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=20): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.positive_float,
             }),
-            cv.Optional(CONF_HC1_DESIGN_TEMP): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_HC1_DESIGN_TEMP): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=90): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=30): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.positive_float,
             }),
 #             handled by CONF_FROSTT_SWITCH
-#            cv.Optional(CONF_HC1_OUTDOORT_SWITCH): number.NUMBER_SCHEMA.extend({
+#            cv.Optional(CONF_HC1_OUTDOORT_SWITCH): number.number_schema(BuderusParamNumber).extend({
 #                cv.GenerateID(): cv.declare_id(BuderusParamNumber),
 #                cv.Optional(CONF_MAX_VALUE, default=10): cv.float_,
 #                cv.Optional(CONF_MIN_VALUE, default=-20): cv.float_,
 #                cv.Optional(CONF_STEP, default=1): cv.positive_float,
 #            }),
-            cv.Optional(CONF_HC1_ROOMT_OFFSET): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_HC1_ROOMT_OFFSET): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=5): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=-5): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
             }),
-            cv.Optional(CONF_HC1_HOLIDAY_DAYS): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_HC1_HOLIDAY_DAYS): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=99): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.positive_float,
             }),
 
-            cv.Optional(CONF_HC2_ROOMT_TARGET_NIGHT): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_HC2_ROOMT_TARGET_NIGHT): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=30): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=10): cv.float_,
                 cv.Optional(CONF_STEP, default=0.5): cv.positive_float,
             }),
-            cv.Optional(CONF_HC2_ROOMT_TARGET_DAY): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_HC2_ROOMT_TARGET_DAY): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=30): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=10): cv.float_,
                 cv.Optional(CONF_STEP, default=0.5): cv.positive_float,
             }),
-            cv.Optional(CONF_HC2_HOLIDAYT): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_HC2_HOLIDAYT): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=30): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=10): cv.float_,
                 cv.Optional(CONF_STEP, default=0.5): cv.positive_float,
             }),
-            cv.Optional(CONF_HC2_FT_MAX): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_HC2_FT_MAX): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=90): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=20): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.positive_float,
             }),
-            cv.Optional(CONF_HC2_DESIGN_TEMP): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_HC2_DESIGN_TEMP): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=90): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=30): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.positive_float,
             }),
 #             handled by CONF_FROSTT_SWITCH
-#            cv.Optional(CONF_HC2_OUTDOORT_SWITCH): number.NUMBER_SCHEMA.extend({
+#            cv.Optional(CONF_HC2_OUTDOORT_SWITCH): number.number_schema(BuderusParamNumber).extend({
 #                cv.GenerateID(): cv.declare_id(BuderusParamNumber),
 #                cv.Optional(CONF_MAX_VALUE, default=10): cv.float_,
 #                cv.Optional(CONF_MIN_VALUE, default=-20): cv.float_,
 #                cv.Optional(CONF_STEP, default=1): cv.positive_float,
 #            }),
-            cv.Optional(CONF_HC2_ROOMT_OFFSET): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_HC2_ROOMT_OFFSET): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=5): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=-5): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
             }),
-            cv.Optional(CONF_HC2_HOLIDAY_DAYS): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_HC2_HOLIDAY_DAYS): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=99): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
@@ -162,26 +162,26 @@ CONFIG_SCHEMA = (
             }),
 
             cv.GenerateID(CONF_KM271_ID): cv.use_id(KM271),
-            cv.Optional(CONF_WW_TEMP_TARGET): number.NUMBER_SCHEMA.extend({
+            cv.Optional(CONF_WW_TEMP_TARGET): number.number_schema(BuderusParamNumber).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamNumber),
                 cv.Optional(CONF_MAX_VALUE, default=60): cv.float_,
                 cv.Optional(CONF_MIN_VALUE, default=30): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.positive_float,
             }),
 
-#            cv.Optional(CONF_BLR_TEMP_MAX): number.NUMBER_SCHEMA.extend({
+#            cv.Optional(CONF_BLR_TEMP_MAX): number.number_schema(BuderusParamNumber).extend({
 #                cv.GenerateID(): cv.declare_id(BuderusParamNumber),
 #                cv.Optional(CONF_MAX_VALUE, default=99): cv.float_,
 #                cv.Optional(CONF_MIN_VALUE, default=-70): cv.float_,
 #                cv.Optional(CONF_STEP, default=1): cv.float_,
 #            }),
-#            cv.Optional(CONF_BLR_PUMPT_TURN_ON): number.NUMBER_SCHEMA.extend({
+#            cv.Optional(CONF_BLR_PUMPT_TURN_ON): number.number_schema(BuderusParamNumber).extend({
 #                cv.GenerateID(): cv.declare_id(BuderusParamNumber),
 #                cv.Optional(CONF_MAX_VALUE, default=60): cv.float_,
 #                cv.Optional(CONF_MIN_VALUE, default=-15): cv.float_,
 #                cv.Optional(CONF_STEP, default=1): cv.float_,
 #            }),
-#            cv.Optional(CONF_TIME_OFFSET): number.NUMBER_SCHEMA.extend({
+#            cv.Optional(CONF_TIME_OFFSET): number.number_schema(BuderusParamNumber).extend({
 #                cv.GenerateID(): cv.declare_id(BuderusParamNumber),
 #                cv.Optional(CONF_MAX_VALUE, default=5): cv.float_,
 #                cv.Optional(CONF_MIN_VALUE, default=-5): cv.float_,

--- a/components/km271_wifi/select.py
+++ b/components/km271_wifi/select.py
@@ -59,67 +59,67 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
 #            cv.GenerateID(CONF_KM271_ID): cv.use_id(KM271),
-#            cv.Optional(CONF_BLR_BUILDING_TYPE): select.SELECT_SCHEMA.extend({
+#            cv.Optional(CONF_BLR_BUILDING_TYPE): select.select_schema(BuderusParamSelect).extend({
 #                cv.GenerateID(): cv.declare_id(BuderusParamSelect),
 #                cv.Optional(CONF_OPTIONS, default={0: 'Leicht', 1: 'Mittel', 2: 'Schwer'}): ensure_option_map
 #            }),
 
             cv.GenerateID(CONF_KM271_ID): cv.use_id(KM271),
-            cv.Optional(CONF_HC1_SWT_SWITCH): select.SELECT_SCHEMA.extend({
+            cv.Optional(CONF_HC1_SWT_SWITCH): select.select_schema(BuderusParamSelect).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamSelect),
                 cv.Optional(CONF_OPTIONS, default={9: 'Sommer', 10: '10°C', 11: '11°C', 12: '12°C', 13: '13°C', 14: '14°C', 15: '15°C', 16: '16°C', 17: '17°C', 18: '18°C', 19: '19°C', 20: '20°C', 21: '21°C', 22: '22°C', 23: '23°C', 24: '24°C', 25: '25°C', 26: '26°C', 27: '27°C', 28: '28°C', 29: '29°C', 30: '30°C', 31: 'Winter'}): ensure_option_map
             }),
             cv.GenerateID(CONF_KM271_ID): cv.use_id(KM271),
-            cv.Optional(CONF_HC1_HEATING_PROGRAM): select.SELECT_SCHEMA.extend({
+            cv.Optional(CONF_HC1_HEATING_PROGRAM): select.select_schema(BuderusParamSelect).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamSelect),
                 cv.Optional(CONF_OPTIONS, default={0: 'Eigen', 1: 'Familie', 2: 'Früh', 3: 'Spät', 4: 'Vormittag', 5: 'Nachmittag', 6: 'Mittag', 7: 'Single', 8: 'Früh'}): ensure_option_map
             }),
             cv.GenerateID(CONF_KM271_ID): cv.use_id(KM271),
-            cv.Optional(CONF_HC1_OPMODE): select.SELECT_SCHEMA.extend({
+            cv.Optional(CONF_HC1_OPMODE): select.select_schema(BuderusParamSelect).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamSelect),
                 cv.Optional(CONF_OPTIONS, default={0: 'Nacht', 1: 'Tag', 2: 'Auto'}): ensure_option_map
             }),
             cv.GenerateID(CONF_KM271_ID): cv.use_id(KM271),
-            cv.Optional(CONF_HC1_LOWERING_TYPE): select.SELECT_SCHEMA.extend({
+            cv.Optional(CONF_HC1_LOWERING_TYPE): select.select_schema(BuderusParamSelect).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamSelect),
                 cv.Optional(CONF_OPTIONS, default={0: 'Abschalt', 1: 'Reduziert', 2: 'Raumhalt (nur mit FB)', 3: 'Aussenhalt'}): ensure_option_map
             }),
             cv.GenerateID(CONF_KM271_ID): cv.use_id(KM271),
-            cv.Optional(CONF_HC1_HEATINGS_TYPE): select.SELECT_SCHEMA.extend({
+            cv.Optional(CONF_HC1_HEATINGS_TYPE): select.select_schema(BuderusParamSelect).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamSelect),
                 cv.Optional(CONF_OPTIONS, default={0: 'Aus', 1: 'Heizkörper'}): ensure_option_map
             }),
 
             cv.GenerateID(CONF_KM271_ID): cv.use_id(KM271),
-            cv.Optional(CONF_HC2_SWT_SWITCH): select.SELECT_SCHEMA.extend({
+            cv.Optional(CONF_HC2_SWT_SWITCH): select.select_schema(BuderusParamSelect).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamSelect),
                 cv.Optional(CONF_OPTIONS, default={9: 'Sommer', 10: '10°C', 11: '11°C', 12: '12°C', 13: '13°C', 14: '14°C', 15: '15°C', 16: '16°C', 17: '17°C', 18: '18°C', 19: '19°C', 20: '20°C', 21: '21°C', 22: '22°C', 23: '23°C', 24: '24°C', 25: '25°C', 26: '26°C', 27: '27°C', 28: '28°C', 29: '29°C', 30: '30°C', 31: 'Winter'}): ensure_option_map
             }),
             cv.GenerateID(CONF_KM271_ID): cv.use_id(KM271),
-            cv.Optional(CONF_HC2_HEATING_PROGRAM): select.SELECT_SCHEMA.extend({
+            cv.Optional(CONF_HC2_HEATING_PROGRAM): select.select_schema(BuderusParamSelect).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamSelect),
                 cv.Optional(CONF_OPTIONS, default={0: 'Eigen', 1: 'Familie', 2: 'Früh', 3: 'Spät', 4: 'Vormittag', 5: 'Nachmittag', 6: 'Mittag', 7: 'Single', 8: 'Früh'}): ensure_option_map
             }),
-            cv.Optional(CONF_HC2_OPMODE): select.SELECT_SCHEMA.extend({
+            cv.Optional(CONF_HC2_OPMODE): select.select_schema(BuderusParamSelect).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamSelect),
                 cv.Optional(CONF_OPTIONS, default={0: 'Nacht', 1: 'Tag', 2: 'Auto'}): ensure_option_map
             }),
             cv.GenerateID(CONF_KM271_ID): cv.use_id(KM271),
-            cv.Optional(CONF_HC2_LOWERING_TYPE): select.SELECT_SCHEMA.extend({
+            cv.Optional(CONF_HC2_LOWERING_TYPE): select.select_schema(BuderusParamSelect).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamSelect),
                 cv.Optional(CONF_OPTIONS, default={0: 'Abschalt', 1: 'Reduziert', 2: 'Raumhalt (nur mit FB)', 3: 'Aussenhalt'}): ensure_option_map
             }),
             cv.GenerateID(CONF_KM271_ID): cv.use_id(KM271),
-            cv.Optional(CONF_HC2_HEATINGS_TYPE): select.SELECT_SCHEMA.extend({
+            cv.Optional(CONF_HC2_HEATINGS_TYPE): select.select_schema(BuderusParamSelect).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamSelect),
                 cv.Optional(CONF_OPTIONS, default={0: 'Aus', 1: 'Heizkörper', 3: 'Fußboden'}): ensure_option_map
             }),
 
-            cv.Optional(CONF_WW_OPMODE): select.SELECT_SCHEMA.extend({
+            cv.Optional(CONF_WW_OPMODE): select.select_schema(BuderusParamSelect).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamSelect),
                 cv.Optional(CONF_OPTIONS, default={0: 'Aus', 1: 'Ein', 2: 'Auto'}): ensure_option_map
             }),
-            cv.Optional(CONF_WW_CIRC_PUMP_INTERVALL): select.SELECT_SCHEMA.extend({
+            cv.Optional(CONF_WW_CIRC_PUMP_INTERVALL): select.select_schema(BuderusParamSelect).extend({
                 cv.GenerateID(): cv.declare_id(BuderusParamSelect),
                 cv.Optional(CONF_OPTIONS, default={0: 'Aus', 1: '1 Start/h', 2: '2 Starts/h', 3: '3 Starts/h', 4: '4 Starts/h', 5: '5 Starts/h', 6: '6 Starts/h', 7: 'An'}): ensure_option_map
             })


### PR DESCRIPTION
This PR removes warnings and errors due to this project using an old ESPHome syntax
With the updated python files I can build the project with a current version of ESPHome without build warnings.