### PR TITLE
fix(ci): pin esphome/workflows to 2025.10.0 to match built ESPHome version

### DIFF
--- a/.github/workflows/publish-firmware.yml
+++ b/.github/workflows/publish-firmware.yml
@@ -83,7 +83,9 @@ jobs:
       - set-release-version
       - check-esphome-names
       - read-firmware-files
-    uses: esphome/workflows/.github/workflows/build.yml@2026.8.1
+    # Pinned to 2025.10.0: esphome/workflows 2026.x uses build-action v8, which
+    # requires ESPHome >= 2026.7.0. Bump together with esphome-version below.
+    uses: esphome/workflows/.github/workflows/build.yml@2025.10.0
     with:
       files: ${{ needs.read-firmware-files.outputs.files }}
       esphome-version: 2025.11.0
@@ -96,6 +98,6 @@ jobs:
       - build-firmware
       - set-release-version
       - read-firmware-files
-    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2026.8.1
+    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2025.10.0
     with:
       version: ${{ needs.set-release-version.outputs.release_version }}

--- a/renovate.json
+++ b/renovate.json
@@ -61,6 +61,20 @@
         "minor",
         "patch"
       ]
+    },
+    {
+      "description": "esphome/workflows 2026.x pulls in build-action v8, which requires ESPHome >= 2026.7.0. Lift this cap only together with the esphome-version bump in publish-firmware.yml.",
+      "matchDepNames": [
+        "esphome/workflows"
+      ],
+      "allowedVersions": "<2026.0.0"
+    },
+    {
+      "description": "build-action v8 requires ESPHome >= 2026.7.0; ci.yml still builds 2025.7.2 / 2025.11.0. Lift this cap only together with the esphome-version matrix bump in ci.yml.",
+      "matchDepNames": [
+        "esphome/build-action"
+      ],
+      "allowedVersions": "<8.0.0"
     }
   ]
 }


### PR DESCRIPTION
Fixes the red `Publish Firmware` pipeline on `main`.

## Cause

#135 bumped the reusable workflows to `esphome/workflows@2026.8.1`. That version uses `esphome/build-action` v8, which hard-fails on any ESPHome older than **2026.7.0**:

> ESPHome 2025.11.0 is not supported by this version of the action; it requires at least ESPHome 2026.7.0.

`publish-firmware.yml` builds with `esphome-version: 2025.11.0`, so all firmware jobs on `main` died after a few seconds. The same mismatch is why #140 (`build-action` v8) fails — `ci.yml` builds 2025.7.2 and 2025.11.0.

## Change

- Pin `build.yml` / `upload-to-gh-release.yml` back to `@2025.10.0` (the last known-good state) and document the coupling inline.
- Cap `esphome/workflows` (`<2026.0.0`) and `esphome/build-action` (`<8.0.0`) in `renovate.json` so the bump cannot come back without the ESPHome version bump it depends on.

## Follow-up

Moving forward to `build-action` v8 / `workflows` 2026.x requires raising the ESPHome versions in `ci.yml` and `publish-firmware.yml` to >= 2026.7.0 (latest stable: 2026.7.4) and dropping 2025.7.2 / 2025.11.0 from the test matrix. That is a support-policy decision, tracked separately.