### PR TITLE
test(ci): build against ESPHome 2026.7.x and build-action v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,12 +85,12 @@ jobs:
           EOF
           echo "Created temporary secrets.yaml for CI build"
       - name: ESPHome ${{ matrix.esphome-version }}
-        uses: esphome/build-action@v8
+        uses: esphome/build-action@v8.0.0
         with:
           yaml-file: ${{ matrix.file }}.yaml
           version: ${{ matrix.esphome-version }}
       - name: ESPHome ${{ matrix.esphome-version }} Factory
-        uses: esphome/build-action@v8
+        uses: esphome/build-action@v8.0.0
         with:
           yaml-file: ${{ matrix.file }}.factory.yaml
           version: ${{ matrix.esphome-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,8 @@ jobs:
       matrix:
         file: ${{ fromJson(needs.read-firmware-files.outputs.files) }}
         esphome-version:
-          - 2025.7.2
-          - 2025.11.0
+          - 2026.7.0
+          - 2026.7.4
           #- stable
           
     steps:
@@ -85,12 +85,12 @@ jobs:
           EOF
           echo "Created temporary secrets.yaml for CI build"
       - name: ESPHome ${{ matrix.esphome-version }}
-        uses: esphome/build-action@v7.4.0
+        uses: esphome/build-action@v8
         with:
           yaml-file: ${{ matrix.file }}.yaml
           version: ${{ matrix.esphome-version }}
       - name: ESPHome ${{ matrix.esphome-version }} Factory
-        uses: esphome/build-action@v7.4.0
+        uses: esphome/build-action@v8
         with:
           yaml-file: ${{ matrix.file }}.factory.yaml
           version: ${{ matrix.esphome-version }}

--- a/.github/workflows/publish-firmware.yml
+++ b/.github/workflows/publish-firmware.yml
@@ -86,7 +86,7 @@ jobs:
     uses: esphome/workflows/.github/workflows/build.yml@2026.8.1
     with:
       files: ${{ needs.read-firmware-files.outputs.files }}
-      esphome-version: 2025.11.0
+      esphome-version: 2026.7.4
       combined-name: buderus-km271
       release-version: ${{ needs.set-release-version.outputs.release_version }}
 


### PR DESCRIPTION
Draft — **diagnostic run, do not merge yet.**

Alternative to #143. Instead of pinning `esphome/workflows` back, this moves the ESPHome versions forward to what `build-action` v8 requires (>= 2026.7.0), which also fixes #140 and matches the devcontainer image bumped in #133 (2026.7.4).

- `ci.yml`: matrix `2025.7.2` / `2025.11.0` -> `2026.7.0` / `2026.7.4`, `build-action` `v7.4.0` -> `v8`
- `publish-firmware.yml`: `esphome-version` `2025.11.0` -> `2026.7.4` (keeps `workflows@2026.8.1`)

The open question this run answers: **do the `km271_wifi` components still compile under ESPHome 2026.7.x?** They have never been tested against 2026.x — the matrix stops at 2025.11.0.

If CI is green, this is the better fix and #143 can be closed. If it is red, #143 (pin back) is the way to go and the 2026.x migration needs real work in the component.

Note that merging this drops ESPHome 2025.x from the test matrix, which is a support-policy decision for the maintainer.